### PR TITLE
Support ARM

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,13 +22,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Install simde
+      - name: Setup lib path
         run: |
           if [ "${{ runner.os }}" == 'macOS' ]; then
-            brew install simde
             echo "DYLD_LIBRARY_PATH=$PWD" >> $GITHUB_ENV
           else
-            sudo apt install libsimde-dev
             echo "LD_LIBRARY_PATH=$PWD" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,14 +19,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Install simde
         run: |
           if [ "${{ runner.os }}" == 'macOS' ]; then
             brew install simde
             echo "DYLD_LIBRARY_PATH=$PWD" >> $GITHUB_ENV
-            echo "CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/opt/homebrew/Cellar/simde/0.8.2/include" >> $GITHUB_ENV
-            echo "C_INCLUDE_PATH=$C_INCLUDE_PATH:/opt/homebrew/Cellar/simde/0.8.2/include" >> $GITHUB_ENV
           else
             sudo apt install libsimde-dev
             echo "LD_LIBRARY_PATH=$PWD" >> $GITHUB_ENV

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,49 @@
+name: CI
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install simde
+        run: |
+          if [ "${{ runner.os }}" == 'macOS' ]; then
+            brew install simde
+            echo "DYLD_LIBRARY_PATH=$PWD" >> $GITHUB_ENV
+            echo "CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/opt/homebrew/Cellar/simde/0.8.2/include" >> $GITHUB_ENV
+            echo "C_INCLUDE_PATH=$C_INCLUDE_PATH:/opt/homebrew/Cellar/simde/0.8.2/include" >> $GITHUB_ENV
+          else
+            sudo apt install libsimde-dev
+            echo "LD_LIBRARY_PATH=$PWD" >> $GITHUB_ENV
+          fi
+
+      - name: Setup clang for osx
+        if: runner.os == 'macOS'
+        run: |
+          brew install llvm libomp
+          echo "/opt/homebrew/bin:/opt/homebrew/opt/llvm/bin" >> $GITHUB_PATH
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
+
+      - name: Build
+        run: |
+          make
+          ls
+      
+      - name: Run test
+        run: ./Test_With_Generated_Input

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "simde"]
+	path = simde
+	url = https://github.com/simd-everywhere/simde-no-tests.git

--- a/Block_Copy.cpp
+++ b/Block_Copy.cpp
@@ -1,4 +1,4 @@
-#include <xmmintrin.h>
+#include "Block_Copy.hxx"
 
 /*!
  * Efficiently copy a block of dimension bx*by*bz from volume with dimension nx*ny*nz starting at location x0,y0,z0.

--- a/Block_Copy.hxx
+++ b/Block_Copy.hxx
@@ -3,7 +3,7 @@
 
 #ifndef MY_AVX_DEFINED
 	#define SIMDE_ENABLE_NATIVE_ALIASES
-	#include <simde/x86/avx512.h>  // SSE intrinsics
+	#include "simde/x86/avx512.h"  // SSE intrinsics
 #endif
 
 void Copy_To_Block(

--- a/Block_Copy.hxx
+++ b/Block_Copy.hxx
@@ -1,7 +1,10 @@
 #ifndef CVX_CVXCOMPRESS_BLOCK_COPY_HXX
 #define CVX_CVXCOMPRESS_BLOCK_COPY_HXX
 
-#include <xmmintrin.h>
+#ifndef MY_AVX_DEFINED
+	#define SIMDE_ENABLE_NATIVE_ALIASES
+	#include <simde/x86/avx512.h>  // SSE intrinsics
+#endif
 
 void Copy_To_Block(
 	float* data,

--- a/CvxCompress.cpp
+++ b/CvxCompress.cpp
@@ -248,6 +248,8 @@ float CvxCompress::Compress(
 	assert(bz == 1 || (bz >= CvxCompress::Min_BZ() && bz <= CvxCompress::Max_BZ() && is_pow2(bz)));
 	float global_rms = use_local_RMS ? 1.0f : Compute_Global_RMS(vol,nx,ny,nz);
 
+	omp_set_num_threads(num_threads);
+
 #define MAX(a,b) (a>b?a:b)
 	int max_bs = MAX(bx,MAX(by,bz));
 #undef MAX
@@ -475,6 +477,8 @@ void CvxCompress::Decompress(
 		printf("Error! Decompress: nx, ny, nz do not match!\n");
 		printf("nx=%d, ny=%d, nz=%d, nx_check=%d, ny_check=%d, nz_check=%d\n",nx,ny,nz,nx_check,ny_check,nz_check);
 	}
+
+	omp_set_num_threads(num_threads);
 
 	assert(nx == nx_check);
 	assert(ny == ny_check);

--- a/CvxCompress.cpp
+++ b/CvxCompress.cpp
@@ -209,6 +209,24 @@ float CvxCompress::Compress(
 	return Compress(scale,vol,nx,ny,nz,bx,by,bz,use_local_RMS,compressed,num_threads,compressed_length);
 }
 
+float CvxCompress::Compress(
+	float scale,
+	float* vol,
+	int nx,
+	int ny,
+	int nz,
+	int bx,
+	int by,
+	int bz,
+	unsigned int* compressed,
+	int num_threads,
+	long& compressed_length 
+	)
+{
+	bool use_local_RMS = false;
+	return Compress(scale,vol,nx,ny,nz,bx,by,bz,use_local_RMS,compressed,num_threads,compressed_length);
+}
+
 
 float CvxCompress::Compress(
 	float scale,

--- a/CvxCompress.cpp
+++ b/CvxCompress.cpp
@@ -5,6 +5,12 @@
 #include <stdio.h>
 #include <omp.h>
 #include <chrono>
+
+#ifndef SIMDE_ENABLE_NATIVE_ALIASES
+	#define SIMDE_ENABLE_NATIVE_ALIASES
+	#include <simde/x86/avx512.h>  // SSE intrinsics
+#endif
+
 #include "CvxCompress.hxx"
 #include "Wavelet_Transform_Fast.hxx"
 #include "Wavelet_Transform_Slow.hxx"  // for comparison in module test
@@ -245,6 +251,7 @@ float CvxCompress::Compress(
 	
 	float glob_mulfac = global_rms != 0.0f ? 1.0f / (global_rms * scale) : 1.0f;
 	compressed[6] = *((unsigned int*)&glob_mulfac);
+	// printf("nx=%d, ny=%d, nz=%d, bx=%d, by=%d, bz=%d, mulfac=%e\n",nx,ny,nz,bx,by,bz,glob_mulfac);
 
 	// flags:
 	// 1 -> use local RMS (global RMS otherwise)
@@ -406,6 +413,14 @@ void CvxCompress::Decompress(
 	int nx_check = ((int*)compressed)[0];
 	int ny_check = ((int*)compressed)[1];
 	int nz_check = ((int*)compressed)[2];
+	// Check sizes and print error message if they don't match.
+	// for nx ny and nz
+	if (nx != nx_check || ny != ny_check || nz != nz_check)
+	{
+		printf("Error! Decompress: nx, ny, nz do not match!\n");
+		printf("nx=%d, ny=%d, nz=%d, nx_check=%d, ny_check=%d, nz_check=%d\n",nx,ny,nz,nx_check,ny_check,nz_check);
+	}
+
 	assert(nx == nx_check);
 	assert(ny == ny_check);
 	assert(nz == nz_check);
@@ -416,16 +431,16 @@ void CvxCompress::Decompress(
 	float glob_mulfac = ((float*)compressed)[6];
 	int flags = ((int*)compressed)[7];
 	bool use_local_RMS = (flags & 1) ? true : false;
-	//printf("nx=%d, ny=%d, nz=%d, bx=%d, by=%d, bz=%d, mulfac=%e\n",nx,ny,nz,bx,by,bz,mulfac);
+	// printf("nx=%d, ny=%d, nz=%d, bx=%d, by=%d, bz=%d, mulfac=%e\n",nx,ny,nz,bx,by,bz,glob_mulfac);
 
 	int nbx = (nx+bx-1)/bx;
 	int nby = (ny+by-1)/by;
 	int nbz = (nz+bz-1)/bz;
 	int nnn = nbx*nby*nbz;
-	//printf("nbx=%d, nby=%d, nbz=%d, nnn=%d\n",nbx,nby,nbz,nnn);
+	// printf("nbx=%d, nby=%d, nbz=%d, nnn=%d\n",nbx,nby,nbz,nnn);
 
 	long* glob_blkoffs = (long*)(compressed+8);
-	
+
 	float* blkmulfac = 0L;
 	unsigned int* bytes;
 	if (use_local_RMS)
@@ -1173,8 +1188,6 @@ bool CvxCompress::Run_Module_Tests(bool verbose, bool exhaustive_throughput_test
 	return forward_passed && inverse_passed && copy_to_block_passed && copy_from_block_passed && copy_round_trip_passed && global_rms_passed;
 }
 
-extern "C"
-{
 //
 float
 cvx_compress(
@@ -1218,4 +1231,3 @@ cvx_decompress_inplace(
 	c.Decompress(vol, nx, ny, nz, compressed, compressed_length);
 }
 //
-}

--- a/CvxCompress.cpp
+++ b/CvxCompress.cpp
@@ -8,7 +8,7 @@
 
 #ifndef SIMDE_ENABLE_NATIVE_ALIASES
 	#define SIMDE_ENABLE_NATIVE_ALIASES
-	#include <simde/x86/avx512.h>  // SSE intrinsics
+	#include "simde/x86/avx512.h"  // SSE intrinsics
 #endif
 
 #include "CvxCompress.hxx"

--- a/CvxCompress.hxx
+++ b/CvxCompress.hxx
@@ -77,6 +77,19 @@ public:
                         unsigned int* compressed,
                         long& compressed_length
                       );
+	float Compress(
+                        float scale,
+                        float* vol,
+                        int nx,
+                        int ny,
+                        int nz,
+                        int bx,
+                        int by,
+                        int bz,
+                        unsigned int* compressed,
+						int num_threads,
+                        long& compressed_length
+                      );
 	/*!< Decompress a 3D wavefield that was compressed with Compress(...) method */
 
 	float* Decompress(

--- a/CvxCompress.hxx
+++ b/CvxCompress.hxx
@@ -21,6 +21,27 @@ public:
 	virtual ~CvxCompress();
 
 	/*!
+	 * Compress a 3D wavefield using a given block size and number of threads
+	 * nx is fast, nz is slow
+	 * scale is a relative threshold for discarding wavelet coefficients.
+	 * recommendation for seismic wave-fields: scale=1e-2->1e-5
+	 * larger scale means higher compression (more lossy)
+	 */
+	float Compress(
+			float scale,
+			float* vol,
+			int nx,
+			int ny,
+			int nz,
+			int bx,
+			int by,
+			int bz,
+			bool use_local_RMS,
+			unsigned int* compressed,
+			int num_threads,
+			long& compressed_length
+		      );
+	/*!
 	 * Compress a 3D wavefield using a given block size
 	 * nx is fast, nz is slow
 	 * scale is a relative threshold for discarding wavelet coefficients.
@@ -57,6 +78,7 @@ public:
                         long& compressed_length
                       );
 	/*!< Decompress a 3D wavefield that was compressed with Compress(...) method */
+
 	float* Decompress(
 			int& nx,
 			int& ny,
@@ -71,9 +93,19 @@ public:
 			int ny,
 			int nz,
 			unsigned int* compressed,
+			int num_threads,
 			long compressed_length 
 		       );
-	
+
+	void Decompress(
+			float* vol,
+			int nx,
+			int ny,
+			int nz,
+			unsigned int* compressed,
+			long compressed_length 
+		       );
+
 	bool Is_Valid_Block_Size(int bx, int by, int bz);
 
 	static int Min_BX() {return  8;}  /*!< Get minimum X block size. Will always be a power of two.*/
@@ -116,6 +148,30 @@ void cvx_decompress_inplace(
     int ny,
     int nz,
     unsigned int* compressed,
+    long compressed_length
+);
+
+float cvx_compress_th(
+    float scale,
+    float* vol,
+    int nx,
+    int ny,
+    int nz,
+    int bx,
+    int by,
+    int bz,
+    unsigned int* compressed,
+	int num_threads,
+    long* compressed_length
+);
+
+void cvx_decompress_inplace_th(
+    float* vol,
+    int nx,
+    int ny,
+    int nz,
+    unsigned int* compressed,
+	int num_threads,
     long compressed_length
 );
 

--- a/CvxCompress.hxx
+++ b/CvxCompress.hxx
@@ -1,6 +1,12 @@
 #ifndef CVX_CVXCOMPRESS_HXX
 #define CVX_CVXCOMPRESS_HXX
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+
 /*!
  * This class implements lossy compression for seismic wavefields.
  * It uses Antonini's 7-9 tap filter wavelet transform.
@@ -32,7 +38,7 @@ public:
 			int bz,
 			bool use_local_RMS,
 			unsigned int* compressed,
-			long& compressed_length 
+			long& compressed_length
 		      );
 	/*!
  	 * Compress a 3D wavefield using a given block size.
@@ -80,6 +86,42 @@ public:
 	bool Run_Module_Tests(bool verbose, bool exhaustive_throughput_tests);  /*!< Execute module tests.*/
 
 };
+
+#endif // __cplusplus
+
+float cvx_compress(
+    float scale,
+    float* vol,
+    int nx,
+    int ny,
+    int nz,
+    int bx,
+    int by,
+    int bz,
+    unsigned int* compressed,
+    long* compressed_length
+);
+
+float* cvx_decompress_outofplace(
+    int* nx,
+    int* ny,
+    int* nz,
+    unsigned int* compressed,
+    long compressed_length
+);
+
+void cvx_decompress_inplace(
+    float* vol,
+    int nx,
+    int ny,
+    int nz,
+    unsigned int* compressed,
+    long compressed_length
+);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/Run_Length_Encode_Slow.cpp
+++ b/Run_Length_Encode_Slow.cpp
@@ -3,7 +3,10 @@
 #include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <immintrin.h>
+
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#include <simde/x86/avx512.h>  // SSE intrinsics
+
 #include "Run_Length_Escape_Codes.hxx"
 
 // un-comment if you want debug printouts during encoding

--- a/Run_Length_Encode_Slow.cpp
+++ b/Run_Length_Encode_Slow.cpp
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 
 #define SIMDE_ENABLE_NATIVE_ALIASES
-#include <simde/x86/avx512.h>  // SSE intrinsics
+#include "simde/x86/avx512.h"  // SSE intrinsics
 
 #include "Run_Length_Escape_Codes.hxx"
 

--- a/Test_With_Generated_Input.cpp
+++ b/Test_With_Generated_Input.cpp
@@ -7,6 +7,8 @@
 #include <chrono>
 #include "CvxCompress.hxx"
 #include <iostream>
+#include <cassert>
+
 using namespace std;
 
 using std::chrono::system_clock;
@@ -98,7 +100,7 @@ int main(int argc, char* argv[])
       {
 	double val1 = vol[idx];
 	double val2 = vol[idx] - vol2[idx];
-	double val3 = vol2[idx];
+	double val3 = vol2[idx] + vol[idx];
 	acc1 += val1 * val1;
 	acc2 += val2 * val2;
 	acc3 += val3 * val3;
@@ -114,7 +116,11 @@ int main(int argc, char* argv[])
     printf("compression ratio (return value) = %.2f:1, compression throughput = %.0f MC/s, decompression throughput = %.0f MC/s, error = %.6e, SNR = %.1f dB\n",ratio,mcells_per_sec1,mcells_per_sec2,error,snr);
     printf("Total compression and decompression times were %.2f seconds\n",tot_elapsed_time);
     double overall_ratio = ((double)volsize * 4.0) / (double)overall_compressed;
-    printf("Total compression ratio (based on compress_length) was %.2f:1, compressed length in bytes = %d \n",overall_ratio, overall_compressed);
+    printf("Total compression ratio (based on compress_length) was %.2f:1, compressed length in bytes = %ld \n",overall_ratio, overall_compressed);
+
+    assert(error < 2e-4);
+    assert(snr > 75.0);
+
   }// itries
   return 0;
 }

--- a/Wavelet_Transform_Fast.hxx
+++ b/Wavelet_Transform_Fast.hxx
@@ -1,8 +1,6 @@
 #ifndef CVX_WAVELET_TRANSFORM_FAST_HXX
 #define CVX_WAVELET_TRANSFORM_FAST_HXX
 
-#include <immintrin.h>
-
 /*!
  * Perform forward wavelet transform.
  * Arguments:

--- a/Wavelet_Transform_Slow.cpp
+++ b/Wavelet_Transform_Slow.cpp
@@ -500,8 +500,9 @@ void Gen_Ds79(const char* path, int min_n, int max_n, int num_vars)
 	fprintf(fp,"/*!\n");
 	fprintf(fp," * Don't edit this code, it was automatically generated.\n");
 	fprintf(fp," * Base functions for wavelet transforms of length %d to %d.\n",1<<min_n,1<<max_n);
-	fprintf(fp," */\n");
-	fprintf(fp,"#include <immintrin.h>\n\n");
+	fprintf(fp," */\n\n");
+	fprintf(fp,"#define  SIMDE_ENABLE_NATIVE_ALIASES \n");
+	fprintf(fp,"#include <simde/x86/avx.h>  // AVX intrinsics\n\n");
 
 	fprintf(fp,"/*\n");
 	fprintf(fp," * Define coefficients for Antonini 7-9 tap filter.\n");
@@ -706,7 +707,6 @@ void Gen_Us79(const char* path, int min_n, int max_n, int num_vars)
 	fprintf(fp," * Don't edit this code, it was automatically generated.\n");
 	fprintf(fp," * Base functions for wavelet transforms of length %d to %d.\n",1<<min_n,1<<max_n);
 	fprintf(fp," */\n");
-	fprintf(fp,"#include <immintrin.h>\n\n");
 
 	fprintf(fp,"/*\n");
 	fprintf(fp," * Define coefficients for Antonini 7-9 tap filter.\n");

--- a/Wavelet_Transform_Slow.cpp
+++ b/Wavelet_Transform_Slow.cpp
@@ -502,7 +502,7 @@ void Gen_Ds79(const char* path, int min_n, int max_n, int num_vars)
 	fprintf(fp," * Base functions for wavelet transforms of length %d to %d.\n",1<<min_n,1<<max_n);
 	fprintf(fp," */\n\n");
 	fprintf(fp,"#define  SIMDE_ENABLE_NATIVE_ALIASES \n");
-	fprintf(fp,"#include <simde/x86/avx.h>  // AVX intrinsics\n\n");
+	fprintf(fp,"#include \"simde/x86/avx.h\"  // AVX intrinsics\n\n");
 
 	fprintf(fp,"/*\n");
 	fprintf(fp," * Define coefficients for Antonini 7-9 tap filter.\n");

--- a/makefile
+++ b/makefile
@@ -1,15 +1,28 @@
-CC = gcc
-CXX = g++
-CFLAGS=-fopenmp -O3 -fPIC -mavx -g
-LDFLAGS=-fopenmp -lm -lrt
+CC ?= gcc
+CXX ?= g++
+
+CFLAGS=-fopenmp -O3 -fPIC -g
+# Check if we're on an x86 architecture and if CC supports -mavx
+ifeq ($(shell uname -m), x86_64)
+    CFLAGS += -mavx
+endif
+
+LDFLAGS=-fopenmp -lm
 TFLAG=-std=c++11
+
+# Detect platform and set library extension accordingly
+ifeq ($(shell uname), Darwin)
+    LIB_EXT = dylib
+else
+    LIB_EXT = so
+endif
 
 OBJECTS=CvxCompress.o Wavelet_Transform_Slow.o Wavelet_Transform_Fast.o Run_Length_Encode_Slow.o Block_Copy.o Read_Raw_Volume.o
 
 all: CvxCompress_Test CvxCompress_Test_Dyn Test_Compression Compress_SEAM_Basin Test_With_Generated_Input
 
-libcvxcompress.so : $(OBJECTS)
-	$(CXX) -shared $(LDFLAGS) -o libcvxcompress.so $(OBJECTS)
+libcvxcompress.$(LIB_EXT) : $(OBJECTS)
+	$(CXX) -shared $(LDFLAGS) -o libcvxcompress.$(LIB_EXT) $(OBJECTS)
 
 Wavelet_Transform_Fast.o: Wavelet_Transform_Fast.cpp Ds79_Base.cpp Us79_Base.cpp 
 	$(CXX) -c $(CFLAGS) $< 
@@ -17,7 +30,7 @@ Wavelet_Transform_Fast.o: Wavelet_Transform_Fast.cpp Ds79_Base.cpp Us79_Base.cpp
 CvxCompress_Test: CvxCompress_Test.o $(OBJECTS)
 	$(CXX) $(LDFLAGS) $(TFLAG) $(OBJECTS)  CvxCompress_Test.o -o CvxCompress_Test
 
-CvxCompress_Test_Dyn: CvxCompress_Test.o libcvxcompress.so
+CvxCompress_Test_Dyn: CvxCompress_Test.o libcvxcompress.$(LIB_EXT)
 	$(CXX) $(LDFLAGS) CvxCompress_Test.o  -L. -lcvxcompress -o $@
 
 CvxCompress_GenCode: CvxCompress_GenCode.o CvxCompress.hxx Wavelet_Transform_Slow.o
@@ -29,10 +42,10 @@ Test_Compression: Test_Compression.o $(OBJECTS)
 Ds79_Base.cpp Us79_Base.cpp: CvxCompress.hxx CvxCompress_GenCode
 	./CvxCompress_GenCode
 
-Compress_SEAM_Basin: Compress_SEAM_Basin.o libcvxcompress.so 
+Compress_SEAM_Basin: Compress_SEAM_Basin.o libcvxcompress.$(LIB_EXT) 
 	$(CXX) $(LDFLAGS) $(TFLAG) $<  -L. -lcvxcompress  -o $@
 
-Test_With_Generated_Input: Test_With_Generated_Input.o libcvxcompress.so 
+Test_With_Generated_Input: Test_With_Generated_Input.o libcvxcompress.$(LIB_EXT) 
 	$(CXX) $(LDFLAGS) $(TFLAG) $<  -L. -lcvxcompress  -o $@
 
 %.o: %.c
@@ -43,5 +56,5 @@ Test_With_Generated_Input: Test_With_Generated_Input.o libcvxcompress.so
 
 clean:
 	rm -f *.o
-	rm -f libcvxcompress.so CvxCompress_Test CvxCompress_Test_Dyn CvxCompress_GenCode Test_Compression Compress_SEAM_Basin Test_With_Generated_Input
+	rm -f libcvxcompress.$(LIB_EXT) CvxCompress_Test CvxCompress_Test_Dyn CvxCompress_GenCode Test_Compression Compress_SEAM_Basin Test_With_Generated_Input
 	rm -f Ds79_Base.cpp Us79_Base.cpp

--- a/makefile
+++ b/makefile
@@ -13,8 +13,10 @@ TFLAG=-std=c++11
 # Detect platform and set library extension accordingly
 ifeq ($(shell uname), Darwin)
     LIB_EXT = dylib
+	rflags = -install_name @rpath/libcvxcompress.dylib
 else
     LIB_EXT = so
+	rflags = 
 endif
 
 OBJECTS=CvxCompress.o Wavelet_Transform_Slow.o Wavelet_Transform_Fast.o Run_Length_Encode_Slow.o Block_Copy.o Read_Raw_Volume.o
@@ -22,7 +24,7 @@ OBJECTS=CvxCompress.o Wavelet_Transform_Slow.o Wavelet_Transform_Fast.o Run_Leng
 all: CvxCompress_Test CvxCompress_Test_Dyn Test_Compression Compress_SEAM_Basin Test_With_Generated_Input
 
 lib: $(OBJECTS)
-	$(CXX) -shared $(LDFLAGS) -o libcvxcompress.$(LIB_EXT) $(OBJECTS)
+	$(CXX) -shared $(LDFLAGS) -o libcvxcompress.$(LIB_EXT) $(OBJECTS) $(rflags)
 
 libcvxcompress.$(LIB_EXT) : $(OBJECTS)
 	$(CXX) -shared $(LDFLAGS) -o libcvxcompress.$(LIB_EXT) $(OBJECTS)


### PR DESCRIPTION
This is a proposed change to the AVX support to switch to `simde` so that it's portable to non-x86 platforms like ARM.

There is also a small tweak to the C interface and to the makefile to bemake it easier to compile on different platforms.

I don't think any of this should be an issue as `simde` is a standard apt/brew/... package, it should still  be easy to install and CvxCompres_jll should only need one extra install for simde (and could now ship it for aarch64 as well)