### PR TITLE
Fix mulfac corner case

### DIFF
--- a/CvxCompress.cpp
+++ b/CvxCompress.cpp
@@ -289,6 +289,9 @@ float CvxCompress::Compress(
 	compressed[5] = bz;
 	
 	float glob_mulfac = global_rms != 0.0f ? 1.0f / (global_rms * scale) : 1.0f;
+	// Some combinations of scale and global_rms lead to Inf when global_rms is very small
+	// breaking decompression.
+	glob_mulfac = !isfinite(glob_mulfac) ? 1.0f : glob_mulfac;
 	compressed[6] = *((unsigned int*)&glob_mulfac);
 	// printf("nx=%d, ny=%d, nz=%d, bx=%d, by=%d, bz=%d, mulfac=%e\n",nx,ny,nz,bx,by,bz,glob_mulfac);
 


### PR DESCRIPTION
Lead to issues with very small wavefields (i.e elastic) with an Inf mulfact that cannot be decompressed with

```bash
Error! Decompress: nx, ny, nz do not match!
nx=540, ny=141, nz=141, nx_check=0, ny_check=0, nz_check=0
```

 I think @jkwashbourne-oss had seen it too in some random runs.