### PR TITLE
Fix arm64 unsigned char decode code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, ubuntu-24.04-arm]
 
     steps:
       - name: Checkout code

--- a/Run_Length_Encode_Slow.cpp
+++ b/Run_Length_Encode_Slow.cpp
@@ -412,7 +412,7 @@ int Run_Length_Decode_Slow(float scale, float* vals, int num_expected_vals, unsi
 		}
 		else
 		{
-			int ival = *p;
+			int ival = (signed char)*p;
 			if (ival > VLESC2 && ival < RLESC3)
 			{
 #ifdef DEBUG_DECODE


### PR DESCRIPTION
On aarch64 `char` are unsigned which leads to incorect decode codes 